### PR TITLE
fix qspinbox hover color

### DIFF
--- a/blender_stylesheet/blender_stylesheet.qss
+++ b/blender_stylesheet/blender_stylesheet.qss
@@ -280,7 +280,7 @@ QSpinBox::down-arrow:hover {
     image: url(images:QSpinBox_down_arrow.png);
 }
 QSpinBox::hover {
-    background: #808080;
+    background: #656565;
 }
 QSpinBox::up-button {
     border-width: 0px;


### PR DESCRIPTION
Made it slightly darker.

Before
<img width="134" height="46" alt="image" src="https://github.com/user-attachments/assets/cb0fef59-055e-42a6-a843-a06b6e2ba16c" />


After
<img width="398" height="35" alt="image" src="https://github.com/user-attachments/assets/1a81652e-97b8-4387-9a1b-cc33d9a8916a" />


Fixes https://github.com/hannesdelbeke/blender-qt-stylesheet/issues/9