### PR TITLE
always show qspinboxbutton

### DIFF
--- a/blender_stylesheet/blender_stylesheet.qss
+++ b/blender_stylesheet/blender_stylesheet.qss
@@ -267,9 +267,10 @@ QAbstractSpinBox::down-button {
     border-width: 0px;
     padding-top: 3px;
     subcontrol-origin: control;
-    subcontrol-position: top left;
+    subcontrol-position: center left;
     width: 13px;
     height: 20px;
+    image: url(images:QSpinBox_down_arrow.png);
 }
 
 QAbstractSpinBox::down-button:hover {
@@ -277,7 +278,6 @@ QAbstractSpinBox::down-button:hover {
 }
 QAbstractSpinBox::down-arrow:hover {
     height: 20px;
-    image: url(images:QSpinBox_down_arrow.png);
 }
 QAbstractSpinBox::hover {
     background: #808080;
@@ -286,16 +286,16 @@ QAbstractSpinBox::up-button {
     border-width: 0px;
     padding-top: 3px;
     subcontrol-origin: control;
-    subcontrol-position: top right;
+    subcontrol-position: center right;
     width: 13px;
     height: 20px;
+    image: url(images:QSpinBox_up_arrow.png);
 }
 QAbstractSpinBox::up-button:hover {
     background:#6b6b6b
 }
 QAbstractSpinBox::up-arrow:hover {
     height: 20px;
-    image: url(images:QSpinBox_up_arrow.png);
 }
 
 


### PR DESCRIPTION
Always show the QSpinBox buttons. I also centered the buttons.

Having them hidden is confusing, it makes the it look like a button. I would have liked the behavior to be like whats in Blender. If you hover the QSpinBox the QSpinBox::up-button turns on. But that doesn't seem to be possible.

The Bottom right button is currently being hovered.

Before
<img width="392" height="84" alt="image" src="https://github.com/user-attachments/assets/2a8b4bbd-a458-4e57-a691-a119ad05e6ab" />

After
<img width="394" height="80" alt="image" src="https://github.com/user-attachments/assets/cc9cbc20-1ca6-40d7-b96c-a287a76805d2" />

Fixes https://github.com/hannesdelbeke/blender-qt-stylesheet/issues/10

